### PR TITLE
[BCC] Update TOC

### DIFF
--- a/Bagnon_Scrap.toc
+++ b/Bagnon_Scrap.toc
@@ -1,4 +1,4 @@
-## Interface: 11303
+## Interface: 20501
 ## Title: |cff20ff20Bagnon Scrap|r
 ## Notes: Makes your Scrap to glow
 ## Author: Jaliborc (João Cardoso)


### PR DESCRIPTION
The addon works just fine but it is marked as outdated in addons list. So just update `Interface` option in the addon's TOC.